### PR TITLE
opa_eval

### DIFF
--- a/src/Opa.Wasm.Benchmarks/Program.cs
+++ b/src/Opa.Wasm.Benchmarks/Program.cs
@@ -31,6 +31,19 @@ namespace Opa.Wasm.Benchmarks
 
 			return output;
 		}
+
+		[Benchmark]
+		public string FastEvaluatePolicy()
+		{
+			using var opaPolicy = new OpaPolicy(_opaModule, _module);
+
+			opaPolicy.SetData(@"{""world"": ""world""}");
+
+			string input = @"{""message"": ""world""}";
+			string output = opaPolicy.FastEvaluate(input);
+
+			return output;
+		}
 	}
 
 	class Program

--- a/src/Opa.Wasm.Benchmarks/Program.cs
+++ b/src/Opa.Wasm.Benchmarks/Program.cs
@@ -44,6 +44,37 @@ namespace Opa.Wasm.Benchmarks
 
 			return output;
 		}
+
+		const int runXTimes = 100;
+
+		[Benchmark]
+		public void RunPolicyX()
+		{
+			using var opaPolicy = new OpaPolicy(_opaModule, _module);
+
+			opaPolicy.SetData(@"{""world"": ""world""}");
+
+			string input = @"{""message"": ""world""}";
+			for (int i = 1; i <= runXTimes; i++)
+			{
+				string output = opaPolicy.Evaluate(input);
+			}
+		}
+
+		[Benchmark]
+		public void FastEvaluatePolicyX()
+		{
+			using var opaPolicy = new OpaPolicy(_opaModule, _module);
+
+			opaPolicy.SetData(@"{""world"": ""world""}");
+
+			string input = @"{""message"": ""world""}";
+
+			for (int i = 1; i <= runXTimes; i++)
+			{
+				string output = opaPolicy.FastEvaluate(input);
+			}
+		}
 	}
 
 	class Program

--- a/src/Opa.Wasm.UnitTests/BasicTests.cs
+++ b/src/Opa.Wasm.UnitTests/BasicTests.cs
@@ -45,5 +45,28 @@ namespace Opa.Wasm.UnitTests
 			Assert.IsTrue(output[0].result.allow);
 			Assert.IsTrue(output[0].result.user_is_admin);
 		}
+
+		[Test]
+		public void HelloWorldTest_FastEvaluate()
+		{
+			using var opaModule = new OpaModule();
+			using var module = opaModule.Load(WasmFiles.HelloWorldExample);
+			using var opaPolicy = new OpaPolicy(opaModule, module);
+
+			string data = new
+			{
+				world = "world"
+			}.ToJson();
+			opaPolicy.SetData(data);
+
+			string input = new
+			{
+				message = "world"
+			}.ToJson();
+			string outputJson = opaPolicy.FastEvaluate(input);
+
+			dynamic output = outputJson.ToDynamic();
+			Assert.IsTrue(output[0].result);
+		}
 	}
 }

--- a/src/Opa.Wasm.UnitTests/Opa.Wasm.UnitTests.csproj
+++ b/src/Opa.Wasm.UnitTests/Opa.Wasm.UnitTests.csproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <None Include="..\..\sample-policies\example.wasm" Link="example.wasm">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="..\..\sample-policies\rbac.wasm" Link="rbac.wasm">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/src/Opa.Wasm/OpaPolicy.Functions.cs
+++ b/src/Opa.Wasm/OpaPolicy.Functions.cs
@@ -48,6 +48,14 @@ namespace Opa.Wasm
 			run?.Invoke(_store, ctxAddr);
 		}
 
+		private int Policy_opa_eval(/*int addr, int entrypoint_id, */
+			int dataaddr, int jsonaddr, int jsonlength, int heapaddr/*, int format*/)
+		{
+			var run = _instance.GetFunction(_store, "opa_eval");
+			return (int)run?.Invoke(_store, 0 /* always 0 */, 0 /* default entry point*/,
+				dataaddr, jsonaddr, jsonlength, heapaddr, 0 /* json format */);
+		}
+
 		private int Policy_opa_eval_ctx_get_result(int ctxAddr)
 		{
 			var run = _instance.GetFunction(_store, "opa_eval_ctx_get_result");

--- a/src/Opa.Wasm/OpaPolicy.cs
+++ b/src/Opa.Wasm/OpaPolicy.cs
@@ -161,13 +161,12 @@ namespace Opa.Wasm
 			return DumpJson(resultAddr);
 		}
 
-		public string FastEvaluate(string inputJson)
+		// https://github.com/open-policy-agent/opa/issues/3696#issuecomment-891662230
+		public string FastEvaluate(string json)
 		{
-			// Policy_opa_heap_ptr_set(_dataHeapPtr);
+			_envMemory.WriteString(_store, _dataHeapPtr, json);
 
-			int inputAddr = LoadJson(inputJson);
-
-			int resultaddr = Policy_opa_eval(_dataAddr, inputAddr, inputJson.Length, _dataHeapPtr);
+			int resultaddr = Policy_opa_eval(_dataAddr, _dataHeapPtr, json.Length, _dataHeapPtr + json.Length);
 
 			return _envMemory.ReadNullTerminatedString(_store, resultaddr);
 		}

--- a/src/Opa.Wasm/OpaPolicy.cs
+++ b/src/Opa.Wasm/OpaPolicy.cs
@@ -161,6 +161,17 @@ namespace Opa.Wasm
 			return DumpJson(resultAddr);
 		}
 
+		public string FastEvaluate(string inputJson)
+		{
+			// Policy_opa_heap_ptr_set(_dataHeapPtr);
+
+			int inputAddr = LoadJson(inputJson);
+
+			int resultaddr = Policy_opa_eval(_dataAddr, inputAddr, inputJson.Length, _dataHeapPtr);
+
+			return _envMemory.ReadNullTerminatedString(_store, resultaddr);
+		}
+
 		public void SetData(string json)
 		{
 			Policy_opa_heap_ptr_set(_baseHeapPtr);


### PR DESCRIPTION
See #14 

```
// * Summary *

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19043.1151 (21H1/May2021Update)
Intel Core i7-6600U CPU 2.60GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
.NET SDK=5.0.302
  [Host]     : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT
  DefaultJob : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT


|             Method |     Mean |     Error |    StdDev |
|------------------- |---------:|----------:|----------:|
|          RunPolicy | 1.938 ms | 0.0294 ms | 0.0275 ms |
| FastEvaluatePolicy | 1.766 ms | 0.0349 ms | 0.0796 ms |

// * Hints *
Outliers
  WasmPolicyExecution.FastEvaluatePolicy: Default -> 8 outliers were removed (2.08 ms..2.34 ms)

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ms   : 1 Millisecond (0.001 sec)

// ***** BenchmarkRunner: End *****
```