### PR TITLE
Fix memory overflow if WriteString exceed memory capacity

### DIFF
--- a/src/Opa.Wasm/OpaPolicy.cs
+++ b/src/Opa.Wasm/OpaPolicy.cs
@@ -119,9 +119,9 @@ namespace Opa.Wasm
 
 			string builtins = DumpJson(Policy_Builtins());
 			Builtins = ParseBuiltinsJson(builtins);
-
-			_dataAddr = LoadJson("{}");
+			
 			_baseHeapPtr = Policy_opa_heap_ptr_get();
+			_dataAddr = LoadJson("{}");
 			_dataHeapPtr = _baseHeapPtr;
 
 			string entrypoints = DumpJson(Policy_Entrypoints());

--- a/src/Opa.Wasm/OpaPolicy.cs
+++ b/src/Opa.Wasm/OpaPolicy.cs
@@ -303,6 +303,8 @@ namespace Opa.Wasm
 		{
 			if (!entrypoint.HasValue) entrypoint = 0; // use default entry point
 
+			EnsureMemoryCapacity(json);
+
 			_envMemory.WriteString(_store, _dataHeapPtr, json);
 
 			int resultaddr = Policy_opa_eval(entrypoint.Value, _dataAddr, _dataHeapPtr, json.Length, _dataHeapPtr + json.Length);
@@ -495,5 +497,16 @@ namespace Opa.Wasm
 			var json = JsonSerializer.Serialize(result);
 			return LoadJson(json);
 		}
-	}
+
+		private void EnsureMemoryCapacity(string value)
+		{
+			var requiredPages = (uint)Math.Ceiling((_dataHeapPtr + value.Length) / (double)Memory.PageSize);
+			var pagesToAdd = requiredPages - _envMemory.GetSize(_store);
+
+			if (pagesToAdd > 0)
+			{
+				_envMemory.Grow(_store, pagesToAdd);
+			}
+		}
+}
 }


### PR DESCRIPTION
- The memory allocated for the initial GetData wasn't reused if different data was loaded.
- `FastEvaluate()` is called when `_dataHeapPtr` is near the end of the memory store, it can overflow the store. I created a method to check the memory capacity and grow as necessary.

