### PR TITLE
IOpaPolicy interface

### DIFF
--- a/src/Opa.Wasm/IOpaPolicy.cs
+++ b/src/Opa.Wasm/IOpaPolicy.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Opa.Wasm
+{
+	public interface IOpaPolicy : IOpaPolicyRuntime, IDisposable
+	{
+		int? AbiMinorVersion { get; }
+		int? AbiVersion { get; }
+		IReadOnlyDictionary<int, string> Builtins { get; }
+		IReadOnlyDictionary<string, int> Entrypoints { get; }
+		IOpaSerializer Serializer { get; set; }
+
+		void RegisterBuiltin<TArg1, TArg2, TArg3, TArg4, TResult>(string name, Func<TArg1, TArg2, TArg3, TArg4, TResult> callback);
+		void RegisterBuiltin<TArg1, TArg2, TArg3, TResult>(string name, Func<TArg1, TArg2, TArg3, TResult> callback);
+		void RegisterBuiltin<TArg1, TArg2, TResult>(string name, Func<TArg1, TArg2, TResult> callback);
+		void RegisterBuiltin<TArg1, TResult>(string name, Func<TArg1, TResult> callback);
+		void RegisterBuiltin<TResult>(string name, Func<TResult> callback);
+		void RegisterSdkBuiltins();
+	}
+
+	public interface IOpaPolicyRuntime : IOpaPolicyRuntimeWithT, IOpaPolicyRuntimeWithJson
+	{
+	}
+
+	public interface IOpaPolicyRuntimeWithT
+	{
+		IOpaResult<T> Evaluate<T>(object input, bool disableFastEvaluate = false);
+		IOpaResult<T> Evaluate<T>(object input, int entrypoint, bool disableFastEvaluate = false);
+		IOpaResult<T> Evaluate<T>(object input, string entrypoint, bool disableFastEvaluate = false);
+		void SetData(object data);
+	}
+
+	public interface IOpaPolicyRuntimeWithJson
+	{
+		string EvaluateJson(string json, bool disableFastEvaluate = false);
+		string EvaluateJson(string json, int entrypoint, bool disableFastEvaluate = false);
+		string EvaluateJson(string json, string entrypoint, bool disableFastEvaluate = false);
+		void SetDataJson(string json);
+	}
+}

--- a/src/Opa.Wasm/OpaPolicy.cs
+++ b/src/Opa.Wasm/OpaPolicy.cs
@@ -5,7 +5,7 @@ using Wasmtime;
 
 namespace Opa.Wasm
 {
-	public partial class OpaPolicy : IDisposable
+	public partial class OpaPolicy : IOpaPolicy
 	{
 		private int _dataAddr;
 		private int _baseHeapPtr;

--- a/src/Opa.Wasm/OpaPolicyModule.cs
+++ b/src/Opa.Wasm/OpaPolicyModule.cs
@@ -16,7 +16,7 @@ namespace Opa.Wasm
 		{
 		}
 
-		public OpaPolicy CreatePolicyInstance(IOpaSerializer serializer = null)
+		public IOpaPolicy CreatePolicyInstance(IOpaSerializer serializer = null)
 		{
 			if (null == serializer) serializer = DefaultOpaSerializer.Instance;
 


### PR DESCRIPTION
@willhausman please have a look at the structure proposed for `IOpaPolicy`. 

The main idea is to be able to split off policy setup from repeated policy execution - the idea is to hand out `I...RuntimeWith...` to consumers after everything has been set up. In some cases the consumer might want to register the builtins themselves, but then pass around the entire interface I'd say.